### PR TITLE
switch default JDK used in container image to the Alpine with OpenJDK 17 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM openjdk:17-alpine
 
 ENV REVIEWDOG_VERSION=v0.14.1
 


### PR DESCRIPTION
update container image to use OpenJDK 17 LTS to address the issue #20 