### PR TITLE
feat: switch base image to more secure (less vulns)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 ENV REVIEWDOG_VERSION=v0.15.0
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dbelyaev/action-checkstyle@v0.9.5
+      - uses: dbelyaev/action-checkstyle@master
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review


### PR DESCRIPTION
- switch base image to `eclipse-temurin:17-jre-alpine`