### PR TITLE
chore(ci): harden GitHub Actions (GITHUB_TOKEN permissions)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
+permissions:
+  contents: read
+
 jobs:
 
   label-pr-size:
+    permissions:
+      pull-requests: write  # for codelytv/pr-size-labeler to add labels & comment on PRs
     name: Label PR size
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -10,10 +10,11 @@ permissions:
 jobs:
 
   label-pr-size:
-    permissions:
-      pull-requests: write  # for codelytv/pr-size-labeler to add labels & comment on PRs
     name: Label PR size
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write  # for codelytv/pr-size-labeler to add labels & comment on PRs
 
     steps:
       - uses: codelytv/pr-size-labeler@v1.8.1


### PR DESCRIPTION
## Summary

This pull request is created by [StepSecurity](https://app.stepsecurity.io/securerepo) at the request of @dbelyaev. Please merge the Pull Request to incorporate the requested changes. Please tag @dbelyaev on your message if you have any questions related to the PR.
## Security Fixes

### Least Privileged GitHub Actions Token Permissions

The GITHUB_TOKEN is an automatically generated secret to make authenticated calls to the GitHub API. GitHub recommends setting minimum token permissions for the GITHUB_TOKEN.

- [GitHub Security Guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)
- [The Open Source Security Foundation (OpenSSF) Security Guide](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)


## Feedback
For bug reports, feature requests, and general feedback; please email support@stepsecurity.io. To create such PRs, please visit https://app.stepsecurity.io/securerepo.


Signed-off-by: StepSecurity Bot <bot@stepsecurity.io>