### PR TITLE
chore(ci): remove pr size labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,27 +9,6 @@ permissions:
 
 jobs:
 
-  label-pr-size:
-    name: Label PR size
-    runs-on: ubuntu-latest
-
-    permissions:
-      pull-requests: write  # for codelytv/pr-size-labeler to add labels & comment on PRs
-
-    steps:
-      - uses: codelytv/pr-size-labeler@54ef36785e9f4cb5ecf1949cfc9b00dbb621d761 # v1.8.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          xs_max_size: '10'
-          s_max_size: '50'
-          m_max_size: '100'
-          l_max_size: '1000'
-          fail_if_xl: 'false'
-          message_if_xl: >
-            This PR exceeds the recommended size of 1000 lines.
-            Please make sure you are NOT addressing multiple issues with one PR.
-            Note this PR might be rejected due to its size.
-
   label-pr-changes:
     name: Label PR changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
remove PR size labeler (adds more issues when running PR from forked automated repos)