### PR TITLE
fix(#230): add Alpine's 'curl' and 'wget'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ ENV CHECKSTYLE_VERSION 10.18.1
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 # hadolint ignore=DL3018
-RUN apk --no-cache add git
+RUN apk --no-cache add curl git wget
 
 # pre-install reviewdog and checkstyle
-RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION} && \
+RUN wget -4 -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION} && \
     mkdir -p /opt/lib && \
-    wget -q -O /opt/lib/checkstyle.jar https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar
+    wget -4 -q -O /opt/lib/checkstyle.jar https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This gets around name resolution issues present on rootless Docker: https://github.com/alpinelinux/docker-alpine/issues/155.