### PR TITLE
chore: adjust trivy scanning

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -41,6 +41,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
           exit-code: '0'
           ignore-unfixed: false
+          trivyignores: '.trivyignore'
 
       - name: Upload Trivy Dockerfile Lint results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
@@ -78,6 +79,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
           exit-code: '0'
           ignore-unfixed: false
+          trivyignores: '.trivyignore'
 
       - name: Upload Trivy image results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# AVD-DS-0026: No HEALTHCHECK instruction defined.
+# Suppressed intentionally — this is a one-shot CLI container used inside
+# GitHub Actions jobs, not a long-running service. A HEALTHCHECK instruction
+# is meaningless for a container that executes a single command and exits.
+AVD-DS-0026

--- a/.trivyignore
+++ b/.trivyignore
@@ -3,3 +3,13 @@
 # GitHub Actions jobs, not a long-running service. A HEALTHCHECK instruction
 # is meaningless for a container that executes a single command and exits.
 AVD-DS-0026
+
+# AVD-DS-0002: Image user should not be 'root'.
+# Suppressed intentionally — the container must start as root so that
+# entrypoint.sh can detect the GitHub Actions workspace bind-mount owner
+# UID/GID, chown internal directories accordingly, and then drop privileges
+# via `exec su-exec <uid:gid>` before doing any real work. No workload code
+# ever runs as root: every code path calls su-exec or falls back to the
+# non-root 'checkstyle' user. Adding a USER instruction would break the
+# bind-mount UID matching. See also: # hadolint ignore=DL3002 in Dockerfile.
+AVD-DS-0002


### PR DESCRIPTION
This pull request improves the Trivy security scanning workflow by introducing a `.trivyignore` file to suppress specific, intentional warnings, and updates the workflow configuration to use this ignore file during scans.

**Trivy scan configuration improvements:**

* Added a `.trivyignore` file to suppress two specific Trivy warnings: missing `HEALTHCHECK` instruction (`AVD-DS-0026`) and running as `root` user (`AVD-DS-0002`), both of which are justified for this container's use case.
* Updated `.github/workflows/trivy.yml` to reference the `.trivyignore` file for both Dockerfile and image scans, ensuring these intentional warnings do not cause noise in scan results. [[1]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bR44) [[2]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bR82)