### PR TITLE
chore: fix zizmor warnings

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,5 +30,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -27,6 +27,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: reviewdog/action-depup@94a1aaf4e4923064019214b48a43276218af7ad5 # v1.6.4
         id: depup
         with:
@@ -64,6 +66,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: reviewdog/action-depup@94a1aaf4e4923064019214b48a43276218af7ad5 # v1.6.4
         id: depup-checkstyle
         with:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] safe usage, no code checkout, API-only actions
     types: [ opened, synchronize ]
 
 # set empty default permissions and define them explicitly in each job for security

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
@@ -79,5 +81,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Post bumpr status comment
         uses: haya14busa/action-bumpr@faf6f474bcb6174125cfc569f0b2e24cbf03d496 # v1.11.4

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -32,6 +32,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd # v1.2.1
         id: reporter
         with:
@@ -60,6 +62,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd # v1.2.1
         id: reporter
         with:
@@ -88,6 +92,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: markdown-lint
         uses: reviewdog/action-markdownlint@3667398db9118d7e78f7a63d10e26ce454ba5f58 # v0.26.2
         with:
@@ -111,6 +117,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -134,6 +142,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: reviewdog/action-alex@b6673b547eeb6d430c87ef02dc3524bdf34e324d # v1.16.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-other.yml
+++ b/.github/workflows/test-other.yml
@@ -161,12 +161,12 @@ jobs:
           checkstyle_config: nonexistent_config.xml
 
       - name: Verify failure
+        env:
+          STEPS_INVALID_CONFIG_OUTCOME: ${{ steps.invalid_config.outcome }}
         if: steps.invalid_config.outcome != 'failure'
         run: |
           echo "Expected failure but got: ${STEPS_INVALID_CONFIG_OUTCOME}"
           exit 1
-        env:
-          STEPS_INVALID_CONFIG_OUTCOME: ${{ steps.invalid_config.outcome }}
 
   test-invalid-version:
     if: github.event_name == 'pull_request'
@@ -193,9 +193,9 @@ jobs:
           checkstyle_version: "999.0.0"
 
       - name: Verify failure
+        env:
+          STEPS_INVALID_VERSION_OUTCOME: ${{ steps.invalid_version.outcome }}
         if: steps.invalid_version.outcome != 'failure'
         run: |
           echo "Expected failure but got: ${STEPS_INVALID_VERSION_OUTCOME}"
           exit 1
-        env:
-          STEPS_INVALID_VERSION_OUTCOME: ${{ steps.invalid_version.outcome }}

--- a/.github/workflows/test-other.yml
+++ b/.github/workflows/test-other.yml
@@ -28,6 +28,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,6 +51,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,6 +76,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -94,6 +100,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -117,6 +125,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -139,6 +149,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run with invalid config (expect failure)
         id: invalid_config
@@ -151,8 +163,10 @@ jobs:
       - name: Verify failure
         if: steps.invalid_config.outcome != 'failure'
         run: |
-          echo "Expected failure but got: ${{ steps.invalid_config.outcome }}"
+          echo "Expected failure but got: ${STEPS_INVALID_CONFIG_OUTCOME}"
           exit 1
+        env:
+          STEPS_INVALID_CONFIG_OUTCOME: ${{ steps.invalid_config.outcome }}
 
   test-invalid-version:
     if: github.event_name == 'pull_request'
@@ -167,6 +181,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run with invalid version (expect failure)
         id: invalid_version
@@ -179,5 +195,7 @@ jobs:
       - name: Verify failure
         if: steps.invalid_version.outcome != 'failure'
         run: |
-          echo "Expected failure but got: ${{ steps.invalid_version.outcome }}"
+          echo "Expected failure but got: ${STEPS_INVALID_VERSION_OUTCOME}"
           exit 1
+        env:
+          STEPS_INVALID_VERSION_OUTCOME: ${{ steps.invalid_version.outcome }}

--- a/.github/workflows/test-reviewers.yml
+++ b/.github/workflows/test-reviewers.yml
@@ -27,6 +27,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,6 +51,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,6 +76,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-versions.yml
+++ b/.github/workflows/test-versions.yml
@@ -28,6 +28,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -50,6 +52,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,6 +76,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -94,6 +100,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -116,6 +124,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,6 +30,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Trivy Dockerfile Lint
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -65,6 +67,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build Docker image for scanning
         run: docker build -t docker-image:${{ github.sha }} .


### PR DESCRIPTION
This pull request updates all GitHub Actions workflow files to explicitly set `persist-credentials: false` when using the `actions/checkout` action. This change enhances security by ensuring that the default GitHub token is not persisted to the local git config, which helps prevent accidental credential leaks during workflow execution.

**Security improvements in workflows:**

* All workflow files now set `persist-credentials: false` for `actions/checkout`, preventing the GitHub token from being stored in the local git config and reducing the risk of credential leaks. [[1]](diffhunk://#diff-c36550fecfdd2e671919cff9058b2fde7bf91be6cd4c21186b0b5e374cb7a466R30-R31) [[2]](diffhunk://#diff-c36550fecfdd2e671919cff9058b2fde7bf91be6cd4c21186b0b5e374cb7a466R69-R70) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R34-R35) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R84-R85) [[5]](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dR35-R36) [[6]](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dR65-R66) [[7]](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dR95-R96) [[8]](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dR120-R121) [[9]](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dR145-R146) [[10]](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18R33-R34) [[11]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR31-R32) [[12]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR54-R55) [[13]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR79-R80) [[14]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR103-R104) [[15]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR128-R129) [[16]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR152-R153) [[17]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR184-R185) [[18]](diffhunk://#diff-f5a71fddc063cb4994c8c1f83c806d9a6817c1b2235e4702387be61bf32a93acR30-R31) [[19]](diffhunk://#diff-f5a71fddc063cb4994c8c1f83c806d9a6817c1b2235e4702387be61bf32a93acR54-R55) [[20]](diffhunk://#diff-f5a71fddc063cb4994c8c1f83c806d9a6817c1b2235e4702387be61bf32a93acR79-R80) [[21]](diffhunk://#diff-d938b11dfd886a506253845a5c41e9a55c7eef835056ce3fffa3bd7a6434ddacR31-R32) [[22]](diffhunk://#diff-d938b11dfd886a506253845a5c41e9a55c7eef835056ce3fffa3bd7a6434ddacR55-R56) [[23]](diffhunk://#diff-d938b11dfd886a506253845a5c41e9a55c7eef835056ce3fffa3bd7a6434ddacR79-R80) [[24]](diffhunk://#diff-d938b11dfd886a506253845a5c41e9a55c7eef835056ce3fffa3bd7a6434ddacR103-R104) [[25]](diffhunk://#diff-d938b11dfd886a506253845a5c41e9a55c7eef835056ce3fffa3bd7a6434ddacR127-R128) [[26]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bR33-R34) [[27]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bR70-R71)

**Workflow consistency and maintainability:**

* Ensures consistent use of secure settings across all workflows, including dependency review, release, reviewdog, Trivy, and various test workflows. [[1]](diffhunk://#diff-c36550fecfdd2e671919cff9058b2fde7bf91be6cd4c21186b0b5e374cb7a466R30-R31) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R34-R35) [[3]](diffhunk://#diff-0858429e63b8667fbf7cc466f8e90dfb43cd7c6ef824edd6c17a0df649745f7dR35-R36) [[4]](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18R33-R34) [[5]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR31-R32) [[6]](diffhunk://#diff-f5a71fddc063cb4994c8c1f83c806d9a6817c1b2235e4702387be61bf32a93acR30-R31) [[7]](diffhunk://#diff-d938b11dfd886a506253845a5c41e9a55c7eef835056ce3fffa3bd7a6434ddacR31-R32) [[8]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bR33-R34)

**Minor improvements:**

* In `test-other.yml`, updates the way job step outcomes are referenced in shell scripts by passing them via environment variables, improving script clarity and reliability. [[1]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR164-R168) [[2]](diffhunk://#diff-c851224b23da2401beee44e430e3813887634b2aa544d43d51b487ab8511f81cR196-R200)