### PR TITLE
fix: remove on push event for reviewdog checks

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,11 +1,8 @@
 name: reviewdog
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
-    types: [ opened, synchronize ]
+    types: [ opened, synchronize, reopened ]
 
 # set empty default permissions and define them explicitly in each job for security
 permissions: {}


### PR DESCRIPTION
- disable reviewdog checks running on push to main (it is mentioned to run as PR checks)