### PR TITLE
test: add container-level entrypoint tests (bats)

### DIFF
--- a/.github/workflows/test-entrypoint.yml
+++ b/.github/workflows/test-entrypoint.yml
@@ -1,0 +1,40 @@
+name: Test - Entrypoint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+# set empty default permissions and define them explicitly in each job for security
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  bats:
+    name: runner / bats (entrypoint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends bats
+
+      # Container-level assertions on what the action actually reports.
+      # Unlike the workflow-level tests these do not touch the GitHub API:
+      # they use reviewdog's local reporter with -filter-mode=nofilter.
+      - name: Run entrypoint tests
+        run: bats --print-output-on-failure --timing tests/entrypoint.bats

--- a/.github/workflows/test-entrypoint.yml
+++ b/.github/workflows/test-entrypoint.yml
@@ -37,4 +37,29 @@ jobs:
       # Unlike the workflow-level tests these do not touch the GitHub API:
       # they use reviewdog's local reporter with -filter-mode=nofilter.
       - name: Run entrypoint tests
-        run: bats --print-output-on-failure --timing tests/entrypoint.bats
+        id: bats
+        run: |
+          set -o pipefail
+          bats --formatter tap tests/entrypoint.bats 2>&1 | tee bats.tap
+
+      # Surface each failing test as a PR annotation instead of leaving the
+      # detail buried in the raw log.
+      - name: Annotate failures
+        if: failure() && steps.bats.outcome == 'failure'
+        run: |
+          python3 - <<'PY'
+          import re
+          lines = open('bats.tap', errors='replace').read().splitlines()
+          for i, line in enumerate(lines):
+              m = re.match(r'not ok \d+ (.*)', line)
+              if not m:
+                  continue
+              name = m.group(1)
+              detail = []
+              for nxt in lines[i + 1:]:
+                  if not nxt.startswith('#'):
+                      break
+                  detail.append(nxt.lstrip('# ').rstrip())
+              msg = '%0A'.join(detail) or 'no detail captured'
+              print(f"::error file=tests/entrypoint.bats,title=bats: {name}::{msg}")
+          PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,12 @@ Here's a quick guide:
     git commit -m "conventional commit formatted message"
     ```
 
+1. Run the entrypoint tests locally (requires Docker and [bats](https://github.com/bats-core/bats-core)). They build the image and assert on what the action actually reports, so they catch regressions the workflow-level tests cannot.
+
+    ```shell
+    bats tests/entrypoint.bats
+    ```
+
 1. Before sending the pull request, make sure to rebase onto the upstream source. This ensures your code is based on the latest available code.
 
     ```shell

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -147,9 +147,23 @@ testdata/java/excluded dir"
   [[ "$output" == *"Application.java"* ]]
 }
 
-@test "fail_level=error fails when error-level violations are reported" {
-  run run_action "INPUT_FAIL_LEVEL=error" "INPUT_LEVEL=error"
+@test "fail_level=warning fails when warning-level violations are reported" {
+  # google_checks.xml reports at severity "warning" (its Checker sets
+  # severity=warning globally), so this - not fail_level=error - is what
+  # actually trips on this fixture. See the note above test-exclude in
+  # .github/workflows/test-other.yml: a fail_level of "error" cannot fire
+  # with this ruleset no matter what the analysis finds.
+  run run_action "INPUT_FAIL_LEVEL=warning"
   [ "$status" -ne 0 ]
+}
+
+@test "fail_level=error does not fire on a warning-severity ruleset" {
+  # Documents the trap rather than asserting a desirable behaviour: with
+  # google_checks.xml every violation is a warning, so fail_level=error
+  # passes even though the code is full of findings.
+  run run_action "INPUT_FAIL_LEVEL=error"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Application.java"* ]]
 }
 
 # --- privilege drop -----------------------------------------------------

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+#
+# Container-level tests for entrypoint.sh.
+#
+# These assert on what the action actually REPORTS, which the workflow-level
+# tests cannot do: those run the action with the default filter-mode 'added',
+# so reviewdog discards every violation outside the PR diff. Since testdata/
+# is untouched by a typical PR, an exclude regression there produces no
+# violations to fail on and the job passes regardless. Here we force
+# -filter-mode=nofilter with the local reporter, so every violation surfaces
+# on stdout and can be grepped.
+#
+# Requires: docker, bats. The image is built once (see setup_file).
+
+setup_file() {
+  export IMAGE="action-checkstyle-test:bats"
+  docker build -q -t "$IMAGE" "$BATS_TEST_DIRNAME/.." >/dev/null
+}
+
+# Runs the action in the container against the repo checkout.
+# Usage: run_action [ENV=VALUE ...]
+run_action() {
+  local -a env_args=()
+  local kv
+  for kv in "$@"; do
+    env_args+=(-e "$kv")
+  done
+  docker run --rm \
+    -v "$BATS_TEST_DIRNAME/..:/github/workspace" \
+    -e GITHUB_WORKSPACE=/github/workspace \
+    -e INPUT_REPORTER=local \
+    -e INPUT_FILTER_MODE=nofilter \
+    -e INPUT_FAIL_LEVEL=none \
+    -e INPUT_LEVEL=info \
+    -e INPUT_WORKDIR=/github/workspace/testdata/java \
+    -e INPUT_CHECKSTYLE_CONFIG=google_checks.xml \
+    "${env_args[@]}" \
+    "$IMAGE" 2>&1
+}
+
+# --- fixture sanity -----------------------------------------------------
+# Without this the exclude tests below could pass vacuously: if the fixture
+# stopped producing violations, "not found in output" would be trivially true.
+
+@test "fixture: excluded files DO produce violations when not excluded" {
+  run run_action
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ExcludedFile.java"* ]]
+  [[ "$output" == *"SpaceExcluded.java"* ]]
+  [[ "$output" == *"AnotherExcluded.java"* ]]
+}
+
+@test "fixture: the non-excluded file always produces violations" {
+  run run_action
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Application.java"* ]]
+}
+
+# --- exclude ------------------------------------------------------------
+
+@test "exclude: an excluded directory is not analyzed" {
+  run run_action "INPUT_EXCLUDE=testdata/java/excluded"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"ExcludedFile.java"* ]]
+  # unrelated files must still be analyzed
+  [[ "$output" == *"Application.java"* ]]
+}
+
+@test "exclude: subdirectories of an excluded directory are excluded too" {
+  run run_action "INPUT_EXCLUDE=testdata/java/excluded"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"AnotherExcluded.java"* ]]
+}
+
+@test "exclude: a directory name containing a space is excluded" {
+  run run_action "INPUT_EXCLUDE=testdata/java/excluded dir"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"SpaceExcluded.java"* ]]
+  [[ "$output" == *"Application.java"* ]]
+}
+
+@test "exclude: multiple newline-separated entries all apply" {
+  run run_action "INPUT_EXCLUDE=testdata/java/excluded
+testdata/java/excluded dir"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"ExcludedFile.java"* ]]
+  [[ "$output" != *"AnotherExcluded.java"* ]]
+  [[ "$output" != *"SpaceExcluded.java"* ]]
+  [[ "$output" == *"Application.java"* ]]
+}
+
+@test "exclude: entries are whitespace-trimmed" {
+  run run_action "INPUT_EXCLUDE=   testdata/java/excluded   "
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"ExcludedFile.java"* ]]
+}
+
+@test "exclude: a path that does not exist is tolerated, not fatal" {
+  run run_action "INPUT_EXCLUDE=testdata/java/does-not-exist-yet"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Application.java"* ]]
+}
+
+# --- properties_file ----------------------------------------------------
+
+@test "properties_file: a variable from the file is resolved into the config" {
+  # max-line-length=50 makes Application.java's long line a violation;
+  # without the properties file Checkstyle cannot resolve ${max-line-length}
+  # and fails, so seeing a LineLength violation proves substitution happened.
+  run run_action \
+    "INPUT_CHECKSTYLE_CONFIG=/github/workspace/testdata/properties_file/test_checks.xml" \
+    "INPUT_PROPERTIES_FILE=/github/workspace/testdata/properties_file/additional.properties"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Line is longer than 50"* ]]
+}
+
+@test "properties_file: omitting it when the config needs a variable fails loudly" {
+  run run_action \
+    "INPUT_CHECKSTYLE_CONFIG=/github/workspace/testdata/properties_file/test_checks.xml"
+  [ "$status" -ne 0 ]
+}
+
+# --- failure modes ------------------------------------------------------
+
+@test "invalid checkstyle config fails with a non-zero exit code" {
+  run run_action "INPUT_CHECKSTYLE_CONFIG=nonexistent_config.xml"
+  [ "$status" -ne 0 ]
+}
+
+@test "nonexistent workdir fails with a clear message" {
+  run run_action "INPUT_WORKDIR=/github/workspace/no/such/dir"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"workdir does not exist"* ]]
+}
+
+@test "invalid checkstyle version fails instead of silently using the bundled jar" {
+  run run_action "INPUT_CHECKSTYLE_VERSION=999.0.0"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Failed to download Checkstyle version"* ]]
+}
+
+# --- fail_level ---------------------------------------------------------
+
+@test "fail_level=none succeeds even though violations exist" {
+  run run_action "INPUT_FAIL_LEVEL=none"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Application.java"* ]]
+}
+
+@test "fail_level=error fails when error-level violations are reported" {
+  run run_action "INPUT_FAIL_LEVEL=error" "INPUT_LEVEL=error"
+  [ "$status" -ne 0 ]
+}
+
+# --- privilege drop -----------------------------------------------------
+
+@test "drops root: analysis runs as the workspace owner (non-root workspace)" {
+  # The container starts as root and su-exec's to the UID owning the
+  # bind-mounted workspace. If that switch broke, HOME would still point at
+  # the root-owned /github/home and reviewdog could not write; assert the
+  # run completes and reports normally.
+  run run_action
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Application.java"* ]]
+}
+
+@test "drops root: a root-owned workspace falls back to the checkstyle user" {
+  # Named volumes are root-owned, which exercises the branch where the
+  # workspace owner is UID 0 and the entrypoint must fall back to its own
+  # non-root user rather than staying root.
+  local vol="bats-root-owned-$$"
+  docker volume create "$vol" >/dev/null
+  run docker run --rm \
+    -v "$vol:/github/workspace" \
+    -v "$BATS_TEST_DIRNAME/..:/repo:ro" \
+    -e GITHUB_WORKSPACE=/github/workspace \
+    -e INPUT_REPORTER=local \
+    -e INPUT_FILTER_MODE=nofilter \
+    -e INPUT_FAIL_LEVEL=none \
+    -e INPUT_LEVEL=info \
+    -e INPUT_WORKDIR=/repo/testdata/java \
+    -e INPUT_CHECKSTYLE_CONFIG=google_checks.xml \
+    "$IMAGE" 2>&1
+  docker volume rm "$vol" >/dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Application.java"* ]]
+}


### PR DESCRIPTION
**Update after the first CI runs.** All 18 tests now pass, and running them surfaced a second, independent gap — described below. Also added a step that turns a failing bats test into a PR annotation, so the detail is inline instead of buried in the raw log.

## Gap 1: the `exclude` tests cannot fail

`testdata/java/excluded/ExcludedFile.java` carries a violation on purpose, so that a broken `exclude` would trip `fail_level: error` in `test-exclude`. But those jobs run with the default **`filter_mode: added`**, so reviewdog discards every violation outside the PR diff — and `testdata/` is untouched by a typical PR (dependency bumps, docs). The violation never reaches the fail-level check, so **the job passes whether `exclude` works or not**.

## Gap 2 (found by this suite): `fail_level: error` can never fire with `google_checks.xml`

The first CI run failed exactly one test — the one asserting that `fail_level=error` trips. It doesn't: **google_checks.xml sets `severity=warning` globally**, so every violation it reports is a warning. `test-exclude`, `test-exclude-multi` and `test-exclude-space` all rely on `fail_level: error` as their failure signal, so they are *doubly* unable to fail — the filter mode discards the violations, and even unfiltered they would never reach the configured level.

The suite now asserts `fail_level=warning` trips, and pins the trap with a test showing `fail_level=error` passing on a repo full of findings.

## The approach

`tests/entrypoint.bats` runs the built container with reviewdog's **local reporter** and **`-filter-mode=nofilter`**, so every violation lands on stdout and can be asserted on — no GitHub API, no token, no PR diff.

18 tests: fixture sanity (so the negative assertions can't pass vacuously) · exclude (directory, nested subdirectory, name with a space, multiple entries, whitespace trimming, nonexistent path tolerated) · properties_file (variable really substituted; omitting it fails loudly) · failure modes (invalid config, nonexistent workdir with its message, invalid version) · fail_level semantics · the su-exec privilege drop including the root-owned-workspace fallback via a named volume.

New `Test - Entrypoint` workflow follows the repo conventions (empty default permissions, harden-runner, SHA-pinned checkout, concurrency, timeout); `CONTRIBUTING.md` documents `bats tests/entrypoint.bats`.

## Suggested follow-up (not in this PR)

The three `test-exclude*` jobs in `test-other.yml` now duplicate what bats covers properly, and their pass is meaningless. Worth either pointing them at a warning-level fail_level or dropping them in favour of the bats suite — happy to do it in a separate PR.

Security findings (unvalidated `checkstyle_version` interpolated into the download URL, missing checksum verification) will follow separately.

🤖 Generated by Claude at the repository owner's request