### PR TITLE
fix: validate checkstyle_version, pin the bundled JAR by sha256

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -75,6 +75,12 @@ jobs:
           version_name: CHECKSTYLE_VERSION
           repo: checkstyle/checkstyle
 
+      # The Dockerfile pins the JAR by sha256; recompute it for the new
+      # version so the bump lands complete instead of failing the build.
+      - name: Update pinned JAR checksum
+        if: steps.depup-checkstyle.outputs.latest != steps.depup-checkstyle.outputs.current
+        run: ./scripts/update-checkstyle-checksum.sh
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:

--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -79,7 +79,7 @@ jobs:
       # version so the bump lands complete instead of failing the build.
       - name: Update pinned JAR checksum
         if: steps.depup-checkstyle.outputs.latest != steps.depup-checkstyle.outputs.current
-        run: ./scripts/update-checkstyle-checksum.sh
+        run: bash ./scripts/update-checkstyle-checksum.sh
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM eclipse-temurin:25.0.3_9-jre-alpine@sha256:c707c0d18cb9e8556380719f80d96a75
 
 ENV REVIEWDOG_VERSION=v0.21.0
 ENV CHECKSTYLE_VERSION=13.9.0
+# sha256 of checkstyle-${CHECKSTYLE_VERSION}-all.jar.
+# Kept in step with CHECKSTYLE_VERSION by scripts/update-checkstyle-checksum.sh,
+# which the depup workflow runs when it bumps the version.
+ENV CHECKSTYLE_SHA256=4aa042449984e3f2ea670b039e39b29e116a037e823c32f59b84d04739a8a94c
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
@@ -16,7 +20,8 @@ RUN wget -4 -q -O /tmp/reviewdog_install.sh https://raw.githubusercontent.com/re
     sh /tmp/reviewdog_install.sh -b /usr/local/bin/ ${REVIEWDOG_VERSION} && \
     rm /tmp/reviewdog_install.sh && \
     mkdir -p /opt/lib && \
-    wget -4 -q -O /opt/lib/checkstyle.jar https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar
+    wget -4 -q -O /opt/lib/checkstyle.jar https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar && \
+    echo "${CHECKSTYLE_SHA256}  /opt/lib/checkstyle.jar" | sha256sum -c -
 
 # Create a non-root user to run the container (Trivy DS-0002)
 RUN addgroup -S checkstyle && adduser -S checkstyle -G checkstyle && \

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Browse available versions on the [Checkstyle releases page](https://github.com/c
 
 **Default:** Latest available version
 
+**Accepted format:** digits and dots only (for example `10.21.0`). Anything else is rejected before any download, because the value is interpolated into the release download URL. Note that a custom version is fetched at runtime and is *not* checksum-verified — only the version bundled in the image is pinned by sha256.
+
 **Example:**
 
 ```yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,6 +86,19 @@ fi
 # user wants to use custom Checkstyle version, try to install it
 if [ -n "${INPUT_CHECKSTYLE_VERSION}" ]; then
   echo '::group::📥 Installing user-defined Checkstyle version ... https://github.com/checkstyle/checkstyle'
+
+  # The version is interpolated into a download URL, so it must be a plain
+  # version number and nothing else. Without this check, path traversal in the
+  # value rewrites the URL to any path on github.com - "../../../owner/repo/
+  # releases/download/v1/evil.jar" resolves to an attacker-controlled artifact
+  # that is then executed by `java -jar`.
+  case "${INPUT_CHECKSTYLE_VERSION}" in
+    *[!0-9.]* | .* | *. | *..*)
+      echo "Invalid checkstyle_version: '${INPUT_CHECKSTYLE_VERSION}'. Expected a version number such as 10.21.0" >&2
+      exit 1
+      ;;
+  esac
+
   url="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${INPUT_CHECKSTYLE_VERSION}/checkstyle-${INPUT_CHECKSTYLE_VERSION}-all.jar"
 
   echo "Custom Checkstyle version has been configured: 'v${INPUT_CHECKSTYLE_VERSION}', try to download from ${url}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,6 +97,11 @@ if [ -n "${INPUT_CHECKSTYLE_VERSION}" ]; then
       echo "Invalid checkstyle_version: '${INPUT_CHECKSTYLE_VERSION}'. Expected a version number such as 10.21.0" >&2
       exit 1
       ;;
+    *)
+      # Digits and dots only, no leading/trailing/doubled dot: accepted.
+      # Spelled out rather than left to fall through, so the accept path is
+      # visible and cannot be mistaken for an oversight.
+      ;;
   esac
 
   url="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${INPUT_CHECKSTYLE_VERSION}/checkstyle-${INPUT_CHECKSTYLE_VERSION}-all.jar"

--- a/scripts/update-checkstyle-checksum.sh
+++ b/scripts/update-checkstyle-checksum.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Recomputes CHECKSTYLE_SHA256 in the Dockerfile to match CHECKSTYLE_VERSION.
+#
+# The depup workflow bumps CHECKSTYLE_VERSION automatically; this keeps the
+# pinned checksum in step, so the version bump does not have to choose between
+# a broken build and an unverified download. Run it manually after editing the
+# version by hand:
+#
+#   ./scripts/update-checkstyle-checksum.sh
+#
+set -euo pipefail
+
+dockerfile="$(dirname "$0")/../Dockerfile"
+
+version="$(grep -oP '^ENV CHECKSTYLE_VERSION=\K.*' "$dockerfile")"
+if [ -z "$version" ]; then
+  echo "could not read CHECKSTYLE_VERSION from $dockerfile" >&2
+  exit 1
+fi
+
+url="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${version}/checkstyle-${version}-all.jar"
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+echo "Fetching ${url}"
+curl -fsSL --retry 3 --max-time 300 -o "$tmp" "$url"
+
+# Guard against a 404 page or a truncated download being hashed happily.
+if ! unzip -qql "$tmp" >/dev/null 2>&1; then
+  echo "downloaded file is not a valid JAR/zip archive" >&2
+  exit 1
+fi
+
+sha="$(sha256sum "$tmp" | cut -d' ' -f1)"
+echo "checkstyle ${version} sha256=${sha}"
+
+tmp_dockerfile="$(mktemp)"
+sed "s|^ENV CHECKSTYLE_SHA256=.*|ENV CHECKSTYLE_SHA256=${sha}|" "$dockerfile" > "$tmp_dockerfile"
+mv "$tmp_dockerfile" "$dockerfile"
+
+grep -n '^ENV CHECKSTYLE_\(VERSION\|SHA256\)=' "$dockerfile"

--- a/scripts/update-checkstyle-checksum.sh
+++ b/scripts/update-checkstyle-checksum.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 dockerfile="$(dirname "$0")/../Dockerfile"
 
 version="$(grep -oP '^ENV CHECKSTYLE_VERSION=\K.*' "$dockerfile")"
-if [ -z "$version" ]; then
+if [[ -z "$version" ]]; then
   echo "could not read CHECKSTYLE_VERSION from $dockerfile" >&2
   exit 1
 fi

--- a/scripts/update-checkstyle-checksum.sh
+++ b/scripts/update-checkstyle-checksum.sh
@@ -7,7 +7,7 @@
 # a broken build and an unverified download. Run it manually after editing the
 # version by hand:
 #
-#   ./scripts/update-checkstyle-checksum.sh
+#   bash scripts/update-checkstyle-checksum.sh
 #
 set -euo pipefail
 
@@ -24,7 +24,12 @@ tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 
 echo "Fetching ${url}"
-curl -fsSL --retry 3 --max-time 300 -o "$tmp" "$url"
+# --proto/--proto-redir pin the scheme to HTTPS for the initial request AND for
+# every redirect. -L is required (GitHub redirects release downloads to
+# release-assets.githubusercontent.com), and without these flags curl follows a
+# redirect to plain http - letting whoever can influence that hop supply the
+# JAR whose checksum we are about to bless as the pinned value.
+curl -fsSL --proto '=https' --proto-redir '=https' --retry 3 --max-time 300 -o "$tmp" "$url"
 
 # Guard against a 404 page or a truncated download being hashed happily.
 if ! unzip -qql "$tmp" >/dev/null 2>&1; then

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -138,9 +138,58 @@ testdata/java/excluded dir"
   [[ "$output" == *"workdir does not exist"* ]]
 }
 
-@test "invalid checkstyle version fails instead of silently using the bundled jar" {
+# --- checkstyle_version validation --------------------------------------
+
+@test "version validation: path traversal in the version is rejected" {
+  # Without validation this rewrites the download URL to an arbitrary path on
+  # github.com, and the fetched JAR is then executed by `java -jar`.
+  run run_action "INPUT_CHECKSTYLE_VERSION=../../../../../../attacker/repo/releases/download/v1/evil.jar?"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid checkstyle_version"* ]]
+  # must be rejected before any download is attempted
+  [[ "$output" != *"Failed to download"* ]]
+}
+
+@test "version validation: shell metacharacters are rejected" {
+  run run_action 'INPUT_CHECKSTYLE_VERSION=10.0;id'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid checkstyle_version"* ]]
+}
+
+@test "version validation: whitespace-bearing values are rejected" {
+  run run_action "INPUT_CHECKSTYLE_VERSION=10.0 --no-check-certificate"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid checkstyle_version"* ]]
+}
+
+@test "version validation: a leading, trailing or doubled dot is rejected" {
+  run run_action "INPUT_CHECKSTYLE_VERSION=.10.0"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid checkstyle_version"* ]]
+
+  run run_action "INPUT_CHECKSTYLE_VERSION=10.0."
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid checkstyle_version"* ]]
+
+  run run_action "INPUT_CHECKSTYLE_VERSION=10..0"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid checkstyle_version"* ]]
+}
+
+@test "version validation: a well-formed version passes validation and downloads" {
+  # Guards against the pattern being so strict it rejects real versions.
+  run run_action "INPUT_CHECKSTYLE_VERSION=10.21.0"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Invalid checkstyle_version"* ]]
+  [[ "$output" == *"Application.java"* ]]
+}
+
+@test "version validation: a well-formed but nonexistent version fails at download" {
+  # 999.0.0 is valid syntax, so it must pass validation and fail later -
+  # proving the check rejects shape, not existence.
   run run_action "INPUT_CHECKSTYLE_VERSION=999.0.0"
   [ "$status" -ne 0 ]
+  [[ "$output" != *"Invalid checkstyle_version"* ]]
   [[ "$output" == *"Failed to download Checkstyle version"* ]]
 }
 


### PR DESCRIPTION
Part 2 of the audit, as planned after #550/#551.

## 1. `checkstyle_version` was interpolated straight into a download URL

Path traversal in the value rewrites that URL to **any path on github.com**, and the fetched artifact is then executed by `java -jar`. Measured, not assumed — with six `../` the URL normalises to:

```
/attacker/repo/releases/download/v1/evil.jar
```

Threat model, stated honestly: the value comes from the workflow author, so this is *not* a "hostile PR compromises the repo" vector. It matters because the input travels — it is routinely wired to `${{ inputs.* }}` of a reusable workflow or to a matrix value, at which point the controlling party is no longer whoever wrote the action step.

**Fix:** the version is validated before anything is fetched — digits and dots only, no leading/trailing dot, no doubled dots. Verified that every real Checkstyle version from `6.19` through `13.9.0` passes, and that traversal, `;id`, whitespace-bearing values (`10.0 --no-check-certificate`), `v`-prefixed tags and `$(id)` are all rejected.

## 2. The bundled JAR had no integrity check

It is now pinned by **sha256** (computed from the real 13.9.0 artifact: `4aa04244…a8a94c`), which also makes the image build reproducible.

The interesting part is keeping that honest under automation: `depup` bumps `CHECKSTYLE_VERSION` on its own, so a hardcoded checksum would either break those PRs or quietly rot. The bump workflow now runs `scripts/update-checkstyle-checksum.sh`, which refetches the JAR, **rejects a non-archive response before hashing it** (so a 404 page can't become the new pin), and rewrites the value — a version bump lands complete. The script is idempotent; I ran it against the current pin and it reproduced the same checksum byte for byte.

## Tests & docs
6 new bats tests (25 total): traversal, metacharacters, whitespace, dot edge cases, a well-formed version downloading successfully, and a well-formed-but-nonexistent version failing **at download rather than at validation** — proving the check rejects shape, not existence. `shellcheck` clean on both scripts.

README documents the accepted format and states plainly that a custom version is fetched at runtime and is **not** checksum-verified — only the bundled one is pinned.

🤖 Generated by Claude at the repository owner's request