### PR TITLE
fix: enforce HTTPS on all downloads, collapse Docker layers, merge nested if

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,22 +9,31 @@ ENV CHECKSTYLE_SHA256=4aa042449984e3f2ea670b039e39b29e116a037e823c32f59b84d04739
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-# hadolint ignore=DL3018
-RUN apk --no-cache add git su-exec wget
-
-# Pre-install reviewdog and checkstyle.
+# Single RUN: packages, downloads and the runtime user in one layer.
+# Splitting them buys no build-cache benefit here anyway - the ENV lines above
+# are what change, and they invalidate everything below regardless.
+#
+# curl rather than wget: it is the only one of the two that can pin the scheme
+# across redirects (--proto/--proto-redir). Both downloads below are redirected
+# by GitHub, so following them without that guarantee would allow a downgrade
+# to plain http. curl is also what the reviewdog install script prefers.
+#
 # Install script is pinned by commit SHA for supply-chain safety;
 # the binary version is controlled separately via REVIEWDOG_VERSION.
 # -4 forces IPv4 to avoid IPv6 routing issues on GitHub Actions runners.
-RUN wget -4 -q -O /tmp/reviewdog_install.sh https://raw.githubusercontent.com/reviewdog/reviewdog/df70ed74df59de7ebfd9276afabd62ea2de4d7dd/install.sh && \
+# hadolint ignore=DL3018
+RUN apk --no-cache add git su-exec curl && \
+    curl -4 -fsSL --proto '=https' --proto-redir '=https' --retry 3 --connect-timeout 30 \
+      -o /tmp/reviewdog_install.sh \
+      https://raw.githubusercontent.com/reviewdog/reviewdog/df70ed74df59de7ebfd9276afabd62ea2de4d7dd/install.sh && \
     sh /tmp/reviewdog_install.sh -b /usr/local/bin/ ${REVIEWDOG_VERSION} && \
     rm /tmp/reviewdog_install.sh && \
     mkdir -p /opt/lib && \
-    wget -4 -q -O /opt/lib/checkstyle.jar https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar && \
-    echo "${CHECKSTYLE_SHA256}  /opt/lib/checkstyle.jar" | sha256sum -c -
-
-# Create a non-root user to run the container (Trivy DS-0002)
-RUN addgroup -S checkstyle && adduser -S checkstyle -G checkstyle && \
+    curl -4 -fsSL --proto '=https' --proto-redir '=https' --retry 3 --connect-timeout 30 \
+      -o /opt/lib/checkstyle.jar \
+      https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${CHECKSTYLE_VERSION}/checkstyle-${CHECKSTYLE_VERSION}-all.jar && \
+    echo "${CHECKSTYLE_SHA256}  /opt/lib/checkstyle.jar" | sha256sum -c - && \
+    addgroup -S checkstyle && adduser -S checkstyle -G checkstyle && \
     mkdir -p /home/checkstyle && \
     chown -R checkstyle:checkstyle /home/checkstyle /opt/lib
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,8 +107,16 @@ if [ -n "${INPUT_CHECKSTYLE_VERSION}" ]; then
   url="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${INPUT_CHECKSTYLE_VERSION}/checkstyle-${INPUT_CHECKSTYLE_VERSION}-all.jar"
 
   echo "Custom Checkstyle version has been configured: 'v${INPUT_CHECKSTYLE_VERSION}', try to download from ${url}"
-  # -4 forces IPv4 to work around intermittent IPv6 routing issues on GitHub Actions runners
-  if ! wget -4 -q --tries=3 --timeout=30 -O /opt/lib/checkstyle.jar "$url"; then
+  # -4 forces IPv4 to work around intermittent IPv6 routing issues on GitHub Actions runners.
+  # --proto/--proto-redir pin the scheme to HTTPS for the request AND every
+  # redirect: GitHub redirects release downloads, and this JAR is executed by
+  # `java -jar` afterwards, so a downgrade to plain http on that hop would let
+  # whoever controls it decide what code runs. wget offers no equivalent
+  # guarantee (--https-only only governs recursive mode), which is why this
+  # uses curl. --connect-timeout rather than --max-time: the latter caps the
+  # whole transfer and a 17 MB JAR on a slow runner would hit it.
+  if ! curl -4 -fsSL --proto '=https' --proto-redir '=https' --retry 3 --connect-timeout 30 \
+      -o /opt/lib/checkstyle.jar "$url"; then
     echo "Failed to download Checkstyle version ${INPUT_CHECKSTYLE_VERSION}" >&2
     exit 1
   fi
@@ -146,14 +154,13 @@ cs_exit=${cs_exit:-0}
 #   254 (-2) internal CheckstyleException
 # Treat only these as hard failures; all other non-zero codes (including large
 # error counts) are passed through to reviewdog.
-if [ "$cs_exit" -eq 255 ] || [ "$cs_exit" -eq 254 ]; then
-  # Only treat as hard failure when Checkstyle produced no usable XML output.
-  # A repo with exactly 254/255 ERROR-level violations would hit these codes
-  # but still produce valid XML that should flow to reviewdog.
-  if [ ! -s "$cs_output" ] || ! head -n 1 "$cs_output" | grep -q '<'; then
-    echo "Checkstyle failed with exit code ${cs_exit}" >&2
-    exit "$cs_exit"
-  fi
+# Hard failure only when one of those codes came WITHOUT usable XML output:
+# a repo with exactly 254/255 ERROR-level violations hits the same codes but
+# still produces valid XML, which should flow to reviewdog instead of aborting.
+if { [ "$cs_exit" -eq 255 ] || [ "$cs_exit" -eq 254 ]; } &&
+   { [ ! -s "$cs_output" ] || ! head -n 1 "$cs_output" | grep -q '<'; }; then
+  echo "Checkstyle failed with exit code ${cs_exit}" >&2
+  exit "$cs_exit"
 fi
 
 # Feed checkstyle XML output into reviewdog; its exit code respects fail-level


### PR DESCRIPTION
All three accepted. One of them is a real fix, two are structural.

## shell:S6506 — the one that matters (entrypoint.sh:111)
This is the gap I flagged in #552 but couldn't close there: the **runtime** download of a custom Checkstyle version followed redirects with no scheme pinned. GitHub redirects release downloads, and the fetched JAR is executed by `java -jar` immediately after — so a downgrade to plain http on that hop decides what code runs inside the action.

`wget` cannot express the constraint (`--https-only` governs recursive mode; I tested it and it did **not** block a plain-http URL). So the downloads move to **curl with `--proto '=https' --proto-redir '=https'`**, which refuses the downgrade on the initial request *and* on every redirect — same guarantee already applied to the checksum script.

Two details worth flagging:
- **`--connect-timeout`, not `--max-time`.** `wget --timeout=30` is per-operation; `curl --max-time` caps the *whole transfer*, and a 17 MB JAR on a slow runner would trip it. Using `--max-time` here would have been a plausible-looking bug.
- **`wget` is dropped from the image.** Nothing else needs it, and the reviewdog install script prefers curl when both are present (verified: it checks `is_command curl` first).

## docker:S7031 — three RUN instructions collapsed into one
No build-cache regression, which is the usual objection: the `ENV` lines sit above and already invalidate every layer below them on any version bump, so the separate layers were buying nothing.

## shelldre:S1066 — nested `if` merged (entrypoint.sh:153)
The 254/255 exit-code guard is now one condition. Verified equivalent across **all 20 combinations** of exit code (0/1/42/254/255) × output state (valid XML / empty / non-XML / missing) — the old and new forms agree on every one.

`shellcheck` clean; the bats suite exercises the new curl path via the "well-formed version downloads" test, and building the image is the first thing it does.

🤖 Generated by Claude at the repository owner's request