### PR TITLE
docs: document why the base image is pinned by tag AND digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+# Pinned by BOTH tag and digest, deliberately. The digest is what Docker
+# enforces; the tag is what tells Renovate which release line to follow and
+# what makes an update PR readable ("update ... tag to v25.0.3_9-jre-alpine"
+# rather than an opaque hex change). Dropping the tag would leave Renovate
+# tracking `latest` by default - silently drifting off the pinned JRE 25
+# Alpine line, which is the opposite of what pinning is for.
+#
+# SonarQube docker:S8431 flags this combination; it is accepted here for the
+# reasons above. Please do not "simplify" this line.
 FROM eclipse-temurin:25.0.3_9-jre-alpine@sha256:c707c0d18cb9e8556380719f80d96a7529d0746fbb42143893949b98ed2f8943
 
 ENV REVIEWDOG_VERSION=v0.21.0


### PR DESCRIPTION
This is the one finding I'd **not** comply with. Analysis below; the PR only adds a comment so the line doesn't get "simplified" later.

## Why keeping both is correct here
Renovate maintains the tag and the digest **independently** — this repository's own history shows both kinds of PR:

```
chore(deps): update eclipse-temurin docker tag to v25.0.3_9-jre-alpine
chore(deps): update eclipse-temurin:25.0.3_9-jre-alpine docker digest to 28db6fd
```

Note the second title: Renovate identifies the image *by its tag* even when updating the digest.

- The **digest** is what Docker enforces — reproducibility and tamper-resistance come from it, and it wins at build time regardless of the tag.
- The **tag** is what tells Renovate which release line to follow. With a digest-only pin Renovate falls back to tracking `latest`, so the image would silently drift off the pinned JRE 25 Alpine line — the opposite of what pinning is for — and every update would land as an opaque hex change with no way to tell a patch bump from a major one at review time.

`tag@digest` is also exactly what Renovate's `config:best-practices` preset — which this repo extends — produces.

## Weighing the rule's actual concern
S8431 exists because a tag can drift from what the digest points at and mislead a reader. Here the two are kept in step automatically, and the failure mode is a cosmetically stale *label* while the build stays deterministic. That's a small, cosmetic risk against a concrete loss of dependency tracking and reviewability.

## Suggested disposition
Merge this comment and mark the issue **Accepted** in SonarCloud. (I didn't add an inline `NOSONAR` — I couldn't verify whether the Docker analyzer honours it, and an ineffective marker would be worse than none.)

🤖 Generated by Claude at the repository owner's request