### PR TITLE
chore: enable signed commits for dependency update PRs

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -50,6 +50,7 @@ jobs:
           branch: depup/reviewdog
           base: master
           labels: "bump:minor"
+          sign-commits: true
 
   checkstyle:
     runs-on: ubuntu-latest
@@ -95,3 +96,4 @@ jobs:
           branch: depup/checkstyle
           base: master
           labels: "bump:minor"
+          sign-commits: true


### PR DESCRIPTION
This pull request introduces a minor but important update to the `.github/workflows/depup.yml` workflow file. The main change is enabling commit signing for automated dependency update branches, which helps ensure the authenticity and integrity of commits made by the workflow.

Workflow improvements:

* Added `sign-commits: true` to the `reviewdog` and `checkstyle` dependency update jobs to ensure that commits created by these jobs are GPG-signed. [[1]](diffhunk://#diff-c36550fecfdd2e671919cff9058b2fde7bf91be6cd4c21186b0b5e374cb7a466R53) [[2]](diffhunk://#diff-c36550fecfdd2e671919cff9058b2fde7bf91be6cd4c21186b0b5e374cb7a466R99)